### PR TITLE
fix(knowledge): scope keyword detail/delete to the caller's tenant (cross-org IDOR)

### DIFF
--- a/internal/bff-service/service/knowledge_keywords.go
+++ b/internal/bff-service/service/knowledge_keywords.go
@@ -97,6 +97,17 @@ func UpdateKnowledgeKeywords(ctx *gin.Context, userId, orgId string, r *request.
 }
 
 func DeleteDocCategoryKeywords(ctx *gin.Context, userId, orgId string, r *request.DeleteKeywordsReq) error {
+	// 删除前校验关键词归属：detail 接口已按 (org,user) 鉴权，非本租户的关键词会返回错误，
+	// 以此拦截跨租户删除（DeleteKnowledgeKeywords 请求自身不携带调用方身份）。
+	if _, err := knowledgeBaseKeywords.GetKnowledgeKeywordsDetail(ctx.Request.Context(), &knowledgebase_keywords_service.GetKnowledgeKeywordsDetailReq{
+		Id: r.Id,
+		Identity: &knowledgebase_keywords_service.Identity{
+			UserId: userId,
+			OrgId:  orgId,
+		},
+	}); err != nil {
+		return err
+	}
 	_, err := knowledgeBaseKeywords.DeleteKnowledgeKeywords(ctx.Request.Context(), &knowledgebase_keywords_service.DeleteKnowledgeKeywordsReq{
 		Id: r.Id,
 	})

--- a/internal/knowledge-service/server/grpc/knowledge_keywords/knowledge_keywords.go
+++ b/internal/knowledge-service/server/grpc/knowledge_keywords/knowledge_keywords.go
@@ -110,6 +110,13 @@ func (s *Service) GetKnowledgeKeywordsDetail(ctx context.Context, req *knowledge
 		log.Errorf(fmt.Sprintf("GetKnowledgeKeywords 失败(%v)  参数(%v)", err, req))
 		return nil, util.ErrCode(errs.Code_KnowledgeKeywordsInfoFailed)
 	}
+	// 校验关键词归属：仅允许访问本租户(org+user)的关键词，避免按 id 跨租户越权读取。
+	// 列表/重复校验接口已通过 WithPermit(org,user) 做此限制，此 detail 接口此前遗漏。
+	if keywords.OrgId != req.Identity.OrgId || keywords.UserId != req.Identity.UserId {
+		log.Errorf(fmt.Sprintf("GetKnowledgeKeywordsDetail 跨租户越权: keyword(org=%v,user=%v) caller(org=%v,user=%v)",
+			keywords.OrgId, keywords.UserId, req.Identity.OrgId, req.Identity.UserId))
+		return nil, util.ErrCode(errs.Code_KnowledgeKeywordsInfoFailed)
+	}
 	// 构造返回体
 	keywordsInfo, err := buildKeywordsInfo(ctx, keywords)
 	if err != nil {


### PR DESCRIPTION
## Summary

The keyword ("专名词") endpoints `GET /v1/knowledge/keywords/detail` and `DELETE /v1/knowledge/keywords` were not scoped to the caller's tenant (`org_id` + `user_id`), so any authenticated user could **read or permanently delete another organization's keyword** by its (small, enumerable) integer `id`. Their sibling endpoints already enforce the boundary — the list / repeat-check helpers use `sqlopt.WithPermit(org, user)`, and the other `/knowledge/*` routes carry `middleware.AuthKnowledge(...)` — these two were the exception.

Root cause:
- `knowledge-service` `GetKnowledgeKeywordsDetail` calls `orm.GetKeywordsById(id)` (scoped by `id` only) and never checks the `Identity` already on the request.
- bff `DeleteDocCategoryKeywords` forwards only `Id` to `DeleteKnowledgeKeywords`, and the ORM `DeleteKeywords` is a bare-`id` `Unscoped()` (hard) delete.

## Change

- **`GetKnowledgeKeywordsDetail`** — after loading the keyword, verify it belongs to the caller (`req.Identity.OrgId`/`UserId`); otherwise return the existing not-found error. Root-cause fix for the read, using the `Identity` already present on the request.
- **bff `DeleteDocCategoryKeywords`** — gate the delete on that now tenant-scoped detail lookup, so a caller can only delete a keyword that is their own (the delete RPC itself carries no `Identity`).

No behaviour change for legitimate same-tenant calls. 18 lines, no proto changes.

## Defense-in-depth follow-up (not in this PR)

Thread the caller `Identity` into `DeleteKnowledgeKeywordsReq` and scope the ORM `DeleteKeywords` with `WithPermit(org, user)` (plus a `RowsAffected == 0 → not-found` check), and/or add `middleware.AuthKnowledge(...)` to the two routes — so the gRPC delete is safe independent of the bff.

Fixes #67

---
Reported and verified with [Sectum AI](https://sectum.ai) — open-source multi-tenant isolation verification.
